### PR TITLE
feat: use discord timestamp for registration date

### DIFF
--- a/src/commands/whois.rs
+++ b/src/commands/whois.rs
@@ -5,6 +5,8 @@ use color_eyre::eyre::{Context as _, OptionExt};
 use poise::CreateReply;
 use serenity::all::{GuildId, Mention, User, UserId};
 use serenity::builder::{CreateEmbed, CreateEmbedFooter};
+use serenity::model::Timestamp;
+use serenity::utils::{FormattedTimestamp, FormattedTimestampStyle};
 use wikiauthbot_db::{msg, DatabaseConnectionInGuild, WhoisResult};
 
 use crate::{Context, Result};
@@ -81,11 +83,9 @@ impl WhoisInfo {
         db: DatabaseConnectionInGuild<'_>,
     ) -> Result<CreateEmbed> {
         let mention = Mention::User(discord_user_id).to_string();
-        let registration = self
-            .registration
-            .split_once("T")
-            .ok_or_eyre("invalid date")?
-            .0;
+
+        let registration = Timestamp::parse(&self.registration)?;
+        let formatted = FormattedTimestamp::new(registration, Option::from(FormattedTimestampStyle::ShortDate));
 
         let global_groups = if !self.groups.is_empty() {
             let mut msg = msg!(
@@ -129,7 +129,7 @@ impl WhoisInfo {
             db,
             "whois",
             mention = mention,
-            registration = registration,
+            registration = formatted,
             home = self.home,
             global_groups = global_groups,
             edits = edits,


### PR DESCRIPTION
Tries to convert the "Registered: 2012-10-28" date in a /whois response to use Discord timestamp formatting. As a bonus, it would show the hour as well on hover. See [Discord Doc Timestamp Styles](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles) for styles.

This uses the Short Date style, which formats as MM/DD/YYYY (or other variants, based on the user's locale, sometimes DD/MM/YYYY, sometimes DD.MM.YYYY, etc)

The code assumes the registration timestamp formatting is RFC 3339, per [Serenity's parse code](https://docs.rs/serenity/latest/src/serenity/model/timestamp.rs.html#127-133).

**This is untested**. I'm not sure how to properly test it, so take this code with a grain of salt. The rescue code was also removed, which might be important. I'm not overly familiar with Rust or Serenity to figure out how to add this back properly.
