### PR TITLE
Adjust wording to welcome message

### DIFF
--- a/resources/de.ftl
+++ b/resources/de.ftl
@@ -37,7 +37,7 @@ welcome_has_auth = Willkommen {$mention}! Du bist bereits als [{$name}](<{$user_
 
 welcome_has_auth_failed = Willkommen {$mention}! Du bist bereits als (Fehler beim Laden der Information!) bestätigt, du musst dich also nicht erneut bestätigen.
 
-welcome = Wil{$mention}, willkommen auf dem inoffiziellen Discord-Server der deutschsprachigen Wikipedia-Community! Wenn du dein Wikimedia-Benutzerkonto bestätigen möchtest (empfohlen), tippe bitte `</auth:1241068923730919464>` ein.
+welcome = Wil{$mention}, willkommen auf dem inoffiziellen Discord-Server der deutschsprachigen Wikipedia-Community! Wenn Sie Ihr Wikimedia-Konto verifizieren möchten (empfohlen), geben Sie bitte `</auth:1241068923730919464>` ein oder klicken Sie darauf.
 
 whois_global_groups = Globale Gruppen: {$groupslist}
 

--- a/resources/en.ftl
+++ b/resources/en.ftl
@@ -37,7 +37,7 @@ welcome_has_auth = Welcome {$mention}! You've already authenticated as [{$name}]
 
 welcome_has_auth_failed = Welcome {$mention}! You've already authenticated (error while trying to fetch info!), so you don't need to authenticate again.
 
-welcome = Welcome {$mention}! If you would like to authenticate (validate) your Wikimedia account, please type or click </auth:1241068923730919464>
+welcome = Welcome {$mention}! If you would like to authenticate (publicly link) your Wikimedia account, please type or click </auth:1241068923730919464>
 
 whois_global_groups = Global groups: {$groupslist}
 

--- a/resources/en.ftl
+++ b/resources/en.ftl
@@ -37,7 +37,7 @@ welcome_has_auth = Welcome {$mention}! You've already authenticated as [{$name}]
 
 welcome_has_auth_failed = Welcome {$mention}! You've already authenticated (error while trying to fetch info!), so you don't need to authenticate again.
 
-welcome = Welcome {$mention}! If you would like to authenticate (validate) your Wikimedia account, please type </auth:1241068923730919464>
+welcome = Welcome {$mention}! If you would like to authenticate (validate) your Wikimedia account, please type or click </auth:1241068923730919464>
 
 whois_global_groups = Global groups: {$groupslist}
 


### PR DESCRIPTION
Often if a slash command is not working as expected for a user, [we recommend](https://discord.com/channels/221049808784326656/1183071121105502298/1303361150385131540) trying to click on the `/auth` link in the welcome message — it may be worth modifying the welcome message to include this option:

```
Welcome {$mention}! If you would like to authenticate (validate) your Wikimedia account, please type or click </auth:1241068923730919464>
```