### PR TITLE
Update de.ftl

### DIFF
--- a/resources/de.ftl
+++ b/resources/de.ftl
@@ -44,7 +44,7 @@ welcome_has_auth = Willkommen {$mention}! Du bist bereits als [{$name}](<{$user_
 
 welcome_has_auth_failed = Willkommen {$mention}! Du bist bereits als (Fehler beim Laden der Information!) bestätigt, du musst dich also nicht erneut bestätigen.
 
-welcome = Hallo {$mention}, willkommen auf dem inoffiziellen Discord-Server der deutschsprachigen Wikipedia-Community! Wenn du dein Wikimedia-Konto verifizieren möchtest (empfohlen), gib bitte `</auth:1241068923730919464>` ein oder klicke darauf.
+welcome = Hallo {$mention}, willkommen auf dem inoffiziellen Discord-Server der deutschsprachigen Wikipedia-Community! Wenn du dein Wikimedia-Konto verifizieren möchtest (empfohlen), gib bitte </auth:1241068923730919464> ein oder klicke darauf.
 
 whois_global_groups = Globale Gruppen: {$groupslist}
 


### PR DESCRIPTION
Without the apostrophes, the command link displays correctly.

<img width="519" height="80" alt="image" src="https://github.com/user-attachments/assets/c74b7b0d-3828-4b45-aabc-9283db4b7613" />
